### PR TITLE
Add kaleidoscope to suggested packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
     "require": {
         "neos/neos": ">=8.0 || dev-master"
     },
+    "suggest": {
+        "sitegeist/kaleidoscope": "Needed to support AssetImageSource property"
+    },
     "autoload": {
         "psr-4": {
             "JvMTECH\\SelectiveMixins\\": "Classes/"


### PR DESCRIPTION
For the AssetImageSource property to work, [sitegeist/kaleidoscope](https://github.com/sitegeist/Sitegeist.Kaleidoscope) is needed.